### PR TITLE
Modification for SorRoleElector

### DIFF
--- a/openregistry-service-impl/src/main/java/org/openregistry/core/service/DefaultPersonService.java
+++ b/openregistry-service-impl/src/main/java/org/openregistry/core/service/DefaultPersonService.java
@@ -552,16 +552,9 @@ public class DefaultPersonService implements PersonService {
         // Iterate over sorRoles. SorRoles may be new or updated.
         for (final SorRole savedSorRole:savedSorPerson.getRoles()){
             logger.info("DefaultPersonService: savedSorPersonRole Found, savedSorRoleID: "+ savedSorRole.getId());
-            Role role = person.findRoleBySoRRoleId(savedSorRole.getId());
-            if (role == null) {
-                logger.info("DefaultPersonService: savedSorPersonRole Found, Role Must be newly added.");
-                //let sor role elector decide if this new role can be converted to calculated one
-                sorRoleElector.addSorRole(savedSorRole,person);
-            }
-            else {
-                logger.info("DefaultPersonService: savedSorPersonRole Found, Role was there before.");
-                role.recalculate(savedSorRole); // role may have been updated, so recalculate.
-            }
+            logger.info("DefaultPersonService: savedSorPersonRole Found, Role Must be newly added.");
+            //let sor role elector decide if this new role can be converted to calculated one
+            sorRoleElector.addSorRole(savedSorRole,person);
             logger.info("Verifying Number of calculated Roles after calculate: "+ person.getRoles().size());
         }
         

--- a/openregistry-test-support/src/main/java/org/jasig/openregistry/test/domain/MockSorRole.java
+++ b/openregistry-test-support/src/main/java/org/jasig/openregistry/test/domain/MockSorRole.java
@@ -56,6 +56,8 @@ public class MockSorRole extends Entity implements SorRole {
 
     private String title;
 
+    private Date end;
+
 	public MockSorRole() {
 	}
 
@@ -246,6 +248,7 @@ public class MockSorRole extends Entity implements SorRole {
 	}
 
 	public void setEnd(Date date) {
+        this.end=date;
 	}
 
 	public Date getStart() {
@@ -253,7 +256,7 @@ public class MockSorRole extends Entity implements SorRole {
 	}
 
 	public Date getEnd() {
-		return null;
+		return end;
 	}
 
     @Override


### PR DESCRIPTION
1-modifying  update person event method to call role elector event if the current sor role has already been promoted to calculated role.

2- minor modification to the MockSorRole to accommodate test cases for sor role elector
